### PR TITLE
Adding healthcheck for DB in prepare phase

### DIFF
--- a/molecule/mock/prepare.yml
+++ b/molecule/mock/prepare.yml
@@ -4,6 +4,11 @@
   gather_facts: no
   tasks:
 
-    - name: Pause to give time for elastic to come up
-      pause:
-        seconds: 20
+    - name: "Wait for Elasticsearch to come up"
+      uri:
+        url: "http://{{ elasticsearch_db | default('localhost') }}:9200/_cluster/health?wait_for_status=green&timeout=30s"
+        status_code: 200
+      register: result
+      until: result.status == 200
+      retries: 30
+      delay: 1

--- a/molecule/static/prepare.yml
+++ b/molecule/static/prepare.yml
@@ -9,6 +9,11 @@
         src: data/interface-data.txt
         dest: /tmp/interface-data.txt
 
-    - name: Pause to give time for elastic to come up
-      pause:
-        seconds: 20
+    - name: "Wait for Elasticsearch to come up"
+      uri:
+        url: "http://{{ elasticsearch_db | default('localhost') }}:9200/_cluster/health?wait_for_status=green&timeout=30s"
+        status_code: 200
+      register: result
+      until: result.status == 200
+      retries: 30
+      delay: 1


### PR DESCRIPTION
Based on feedback from the team, this PR is to change the `prepare` pipeline stage to wait for the DB health check to be green instead of just waiting 20 seconds.

This modifies the `prepare.yml` on the scenarios:
- `static`
- `mock`