### PR TITLE
Deleting misleading parameters about connection plugin shown in demo

### DIFF
--- a/molecule/mock/molecule.yml
+++ b/molecule/mock/molecule.yml
@@ -6,9 +6,6 @@ driver:
   name: delegated
   options:
     managed: True
-    ansible_connection_options:
-      ansible_connection: network_cli
-      connection: network_cli
 
 lint: |
     yamllint playbooks/collect_mocked_data.yml playbooks/verify.yml
@@ -49,9 +46,6 @@ platforms:
 provisioner:
   name: ansible
   # log: true
-  config_options:
-    defaults:
-      ansible_connection: network_cli
   lint:
     name: ansible-lint
   playbooks:


### PR DESCRIPTION
Those are not needed since the setting is done directly on the `create.yml` for that scenario.